### PR TITLE
Reliability

### DIFF
--- a/ESP32-project/main/config.h
+++ b/ESP32-project/main/config.h
@@ -32,6 +32,7 @@
 #define POWER_SAVING_TAG "POWER_SAVING"
 #define HTTP_TAG "HTTP_CLIENT"
 #define NVS_TAG "NVS"
+#define DEVICE_MAJORITY_VOTE_TAG "DEVICE_MAJORITY_VOTE"
 
 // MQTT
 #define ALLOW_AUTHENTICATION_TOPIC "/allow_authentication"
@@ -39,7 +40,12 @@
 #define RESPONSE_ACCESS_LIST_TOPIC "/response_access_list"
 #define REQUEST_ACCESS_LIST_TOPIC "/request_access_list"
 #define AUTHENTICATE_TOPIC "/authenticate"
+#define DEVICE_MAJORITY_VOTE_TOPIC "/device_majority_vote"
+#define DEVICE_MAJORITE_RESPONSE_TOPIC "/device_majority_response"
 
 // NVS
 #define STORAGE_NAMESPACE "storage"
 #define UIDS_STORAGE_KEYS "uids"
+
+// MAJORITY VOTING PROCEDURE
+#define MAX_DEVICES_PARTICIPATING_MAJ_VOTE 5 // Maximum number of devices participating in the majority voting procedure

--- a/ESP32-project/main/config.h
+++ b/ESP32-project/main/config.h
@@ -31,3 +31,15 @@
 #define MQTT_TAG "MQTT"
 #define POWER_SAVING_TAG "POWER_SAVING"
 #define HTTP_TAG "HTTP_CLIENT"
+#define NVS_TAG "NVS"
+
+// MQTT
+#define ALLOW_AUTHENTICATION_TOPIC "/allow_authentication"
+#define ACCESS_LIST_TOPIC "/access_list"
+#define RESPONSE_ACCESS_LIST_TOPIC "/response_access_list"
+#define REQUEST_ACCESS_LIST_TOPIC "/request_access_list"
+#define AUTHENTICATE_TOPIC "/authenticate"
+
+// NVS
+#define STORAGE_NAMESPACE "storage"
+#define UIDS_STORAGE_KEYS "uids"

--- a/ESP32-project/main/main.c
+++ b/ESP32-project/main/main.c
@@ -28,6 +28,13 @@ static bool waiting_edge_response_access_list = false;
 static bool result_edge_response = false;
 static bool authenticating = false;
 static bool powersavings_active = false;
+
+// Device Majorty Vote for Access List
+static bool device_majority_vote = false; // Boolean to check if device voting is underway
+static char majority_vote_uid_list[MAX_DEVICES_PARTICIPATING_MAJ_VOTE][MAX_UIDS][UID_LENGTH]; // Array to store UIDs for majority voting from at maximum 5 other devices
+static int majority_vote_count = 0; // Counter for the number of devices participating in the majority voting procedure
+// ----------------------------
+
 static char waiting_uid[11];
 spi_device_handle_t spi; // Handle for the SPI device
 
@@ -82,6 +89,136 @@ void setup_auth_data(const char *uid, const char *node_id, bool result, Authenti
 
     auth_data->result = result;
 }
+
+// Helper function to compare two lists of UIDs
+int compare_uid_lists(char list1[MAX_UIDS][UID_LENGTH], char list2[MAX_UIDS][UID_LENGTH]) {
+    for (int i = 0; i < MAX_UIDS; i++) {
+        if (strcmp(list1[i], list2[i]) != 0) {
+            return 0; // Lists are not equal
+        }
+    }
+    return 1; // Lists are equal
+}
+
+// Function to count votes for a particular UID list
+int count_votes_for_list(char uid_list[MAX_UIDS][UID_LENGTH], int device_count) {
+    int votes = 0;
+    for (int i = 0; i < device_count; i++) {
+        if (compare_uid_lists(uid_list, majority_vote_uid_list[i])) {
+            votes++;
+        }
+    }
+    return votes;
+}
+
+// Function that concludes the majority voting procedure by checking the majority vote UID list and updating the access list, by comparing
+// the array of UIDs for the 5 devices participating + the own device UID listin the majority voting procedure and updating the access list 
+// with the list of UIDs that was voted for by the majority of the devices, by comparing if the lists are equal. If no majority is reached, 
+// the access list is not updated.
+void conclude_majority_voting() {
+    int total_devices = majority_vote_count + 1; // Including the device itself
+    int majority_threshold = total_devices / 2 + 1;
+    int max_votes = 0;
+    char majority_list[MAX_UIDS][UID_LENGTH];
+    int majority_found = 0;
+
+    for (int i = 0; i < majority_vote_count; i++) {
+        int votes = 0;
+        for (int j = 0; j < majority_vote_count; j++) {
+            if (compare_uid_lists(majority_vote_uid_list[i], majority_vote_uid_list[j])) {
+                votes++;
+            }
+        }
+        // Compare with the device's own list
+        if (compare_uid_lists(majority_vote_uid_list[i], valid_uids)) {
+            votes++;
+        }
+        if (votes > max_votes) {
+            max_votes = votes;
+            memcpy(majority_list, majority_vote_uid_list[i], sizeof(majority_list));
+        }
+    }
+
+    // Compare the device's own list with others
+    int device_votes = 0;
+    for (int i = 0; i < majority_vote_count; i++) {
+        if (compare_uid_lists(valid_uids, majority_vote_uid_list[i])) {
+            device_votes++;
+        }
+    }
+    if (device_votes + 1 > max_votes) { // +1 for the device's own vote
+        max_votes = device_votes + 1;
+        memcpy(majority_list, valid_uids, sizeof(majority_list));
+    }
+
+    if (max_votes >= majority_threshold) {
+        const char* uids[MAX_UIDS];
+        for (int i = 0; i < MAX_UIDS; i++) {
+            uids[i] = majority_list[i];
+        }
+        update_access_list(uids, MAX_UIDS);
+        save_uids_to_nvs();
+
+        majority_found = 1;
+        ESP_LOGI(DEVICE_MAJORITY_VOTE_TAG, "Majority reached. Access list updated.\n");
+    }
+
+    if (!majority_found) {
+        ESP_LOGI(DEVICE_MAJORITY_VOTE_TAG, "No majority reached. Access list not updated.\n");
+    }
+}
+
+
+// Task that starts a majority voting procedure for the access list with this node_id by publishing at /device_majority_vote with the nodeId as the payload
+static void majority_voting_task(void *pvParameters)
+{
+    if (!device_majority_vote) {
+
+        // Reset the majority vote UID list to empty strings for all participating devices
+        for (int i = 0; i < MAX_DEVICES_PARTICIPATING_MAJ_VOTE; i++)
+        {
+            for (int j = 0; j < MAX_UIDS; j++)
+            {
+                memset(majority_vote_uid_list[i][j], 0, UID_LENGTH);
+            }
+        }
+
+        // Reset the majority vote count
+        majority_vote_count = 0;
+
+        device_majority_vote = true;
+        // Publish the majority voting message to the /device_majority_vote topic
+        char json[100];
+        sprintf(json, "{\"node_id\":\"%s\"}", NODE_ID);
+        mqtt_publish(DEVICE_MAJORITY_VOTE_TOPIC, json);
+
+
+        ESP_LOGI(DEVICE_MAJORITY_VOTE_TAG, "Majority voting procedure started.\n");
+
+        // Wait 10s for the response from the other devices by using 
+        for (int i = 0; i < 20; i++)
+        {
+            vTaskDelay(500 / portTICK_PERIOD_MS);
+            // Switch the Yellow LED on and off to indicate waiting for response, starting with off
+            gpio_set_level(LED_YELLOW, i % 2);
+            if (!device_majority_vote)
+            {
+                gpio_set_level(LED_YELLOW, 0);
+                break;
+            }
+        }
+
+        gpio_set_level(LED_YELLOW, 0);
+
+        conclude_majority_voting();
+    } else {
+        ESP_LOGW(DEVICE_MAJORITY_VOTE_TAG, "Majority voting procedure already in progress.\n");
+    }
+
+    vTaskDelete(NULL);
+}
+
+
 
 // Function that authenticates the user
 void authenticate_NFC(char *uid)
@@ -229,6 +366,8 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
         esp_mqtt_client_subscribe(client, ALLOW_AUTHENTICATION_TOPIC, 0);
         esp_mqtt_client_subscribe(client, ACCESS_LIST_TOPIC, 0);
         esp_mqtt_client_subscribe(client, RESPONSE_ACCESS_LIST_TOPIC, 0);
+        esp_mqtt_client_subscribe(client, DEVICE_MAJORITY_VOTE_TOPIC, 0);
+        esp_mqtt_client_subscribe(client, DEVICE_MAJORITE_RESPONSE_TOPIC, 0);
 
         break;
     case MQTT_EVENT_DISCONNECTED:
@@ -306,7 +445,7 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
                     // and update the access list by calling void update_access_list(const char* uids[], int count);
                     cJSON *root = cJSON_Parse(event->data);
                     if (root == NULL) {
-                        printf("Error parsing JSON\n");
+                        ESP_LOGE(MQTT_TAG, "Error parsing JSON\n");
                         return;
                     }
                     
@@ -337,7 +476,7 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
                 // and update the access list by calling void update_access_list(const char* uids[], int count);
                 cJSON *root = cJSON_Parse(event->data);
                 if (root == NULL) {
-                    printf("Error parsing JSON\n");
+                    ESP_LOGE(MQTT_TAG, "Error parsing JSON\n");
                     return;
                 }
                 
@@ -358,6 +497,73 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
                 // Save UIDs to NVS periodically
                 save_uids_to_nvs();
                 ESP_LOGI(MQTT_TAG, "Access list updated.\n");
+            }
+        } else if (strncmp(event->topic, DEVICE_MAJORITY_VOTE_TOPIC, event->topic_len) == 0) {
+            // Check if the message is a JSON message
+            if (event->data[0] == '{') {
+                // The message has the format: {"node_id":"str"}
+                // Check if the node_id is the same as the current node_id
+                cJSON *root = cJSON_Parse(event->data);
+                if (root == NULL) {
+                    ESP_LOGE(MQTT_TAG, "Error parsing JSON\n");
+                    return;
+                }
+                
+                cJSON *node_id = cJSON_GetObjectItem(root, "node_id");
+                if (node_id != NULL && cJSON_IsString(node_id)) {
+                    if (strcmp(node_id->valuestring, NODE_ID) != 0) {
+                        // Publish your vote directed at the node_id that sent the original message by publishing with the format: {"node_id":"str","uids":["str1","str2",...]}
+                        cJSON *uids = cJSON_CreateArray();
+                        for (int i = 0; i < MAX_UIDS; i++) {
+                            cJSON *uid = cJSON_CreateString(valid_uids[i]);
+                            cJSON_AddItemToArray(uids, uid);
+                        }
+                        cJSON *vote = cJSON_CreateObject();
+                        cJSON_AddStringToObject(vote, "node_id", NODE_ID);
+                        cJSON_AddItemToObject(vote, "uids", uids);
+                        char *vote_str = cJSON_Print(vote);
+                        ESP_LOGI(MQTT_TAG, "Sending majority voting message to %s\n", node_id->valuestring);
+                        mqtt_publish(DEVICE_MAJORITE_RESPONSE_TOPIC, vote_str);
+                        cJSON_Delete(vote);
+                        free(vote_str);
+                    } else {
+                        ESP_LOGW(MQTT_TAG, "Received majority voting message from the same node. Ignoring.\n");
+                    }
+                } else {
+                    ESP_LOGE(MQTT_TAG, "Invalid JSON message received.\n");
+                }
+                cJSON_Delete(root);
+            }
+        } else if (strncmp(event->topic, DEVICE_MAJORITE_RESPONSE_TOPIC, event->topic_len) == 0) {
+            if (device_majority_vote) {
+                // Check if the message is a JSON message
+                if (event->data[0] == '{') {
+                    // The message has the format: {"node_id":"str","uids":["str1","str2",...]}
+                    // and store the received UID list in the majority_vote_uid_list array
+                    cJSON *root = cJSON_Parse(event->data);
+                    if (root == NULL) {
+                        ESP_LOGE(MQTT_TAG, "Error parsing JSON\n");
+                        return;
+                    }
+                    
+                    cJSON *node_id = cJSON_GetObjectItem(root, "node_id");
+                    cJSON *uids = cJSON_GetObjectItem(root, "uids");
+                    if (node_id != NULL && cJSON_IsString(node_id) && uids != NULL && cJSON_IsArray(uids)) {
+                        cJSON *uid;
+                        int i = 0;
+                        cJSON_ArrayForEach(uid, uids) {
+                            if (cJSON_IsString(uid)) {
+                                strcpy(majority_vote_uid_list[majority_vote_count][i], uid->valuestring);
+                                i++;
+                            }
+                        }
+                        majority_vote_count++;
+                        ESP_LOGI(MQTT_TAG, "Received majority voting message");
+                    } else {
+                        ESP_LOGE(MQTT_TAG, "Invalid JSON message received.\n");
+                    }
+                    cJSON_Delete(root);
+                }
             }
         }
         break;
@@ -582,6 +788,9 @@ void obtain_access_list() {
     if (use_nvs) {
         // Load UIDs from NVS
         load_uids_from_nvs();
+
+        // Start the majority voting task
+        xTaskCreate(majority_voting_task, "majority_voting_task", 4096, NULL, 5, NULL);
     }
     
 

--- a/ESP32-project/main/mqtt.h
+++ b/ESP32-project/main/mqtt.h
@@ -15,4 +15,5 @@ typedef struct {
     bool result;        // Result as boolean
 } AuthenticatedMessage;
 
-void mqtt_app_start(void);
+void log_error_if_nonzero(const char *message, int error_code);
+void mqtt_publish(char *topic, char *data);

--- a/ESP32-project/main/security.c
+++ b/ESP32-project/main/security.c
@@ -149,10 +149,4 @@ void load_uids_from_nvs() {
     uid_count = (int)uid_count_temp;
 
     ESP_LOGI(NVS_TAG, "UIDs loaded from NVS successfully.");
-
-    // Print the loaded UIDs
-    ESP_LOGI(NVS_TAG, "Loaded UIDs:");
-    for (int i = 0; i < uid_count_temp; i++) {
-        ESP_LOGI(NVS_TAG, "UID %d: %s", i, valid_uids[i]);
-    }
 }

--- a/ESP32-project/main/security.c
+++ b/ESP32-project/main/security.c
@@ -2,6 +2,9 @@
 #include <string.h>
 #include "freertos/FreeRTOS.h"
 #include "security.h"
+#include "config.h"
+#include "nvs_flash.h"
+#include "esp_log.h"
 
 char valid_uids[MAX_UIDS][UID_LENGTH]; // Array to store UIDs
 int head = 0; // Head index for the circular buffer
@@ -21,6 +24,17 @@ void add_uid(const char* uid) {
     uid_count++;
 }
 
+// Update the access list with a new list of encrypted UIDs by replacing the old list
+void update_access_list(const char* uids[], int count) {
+    head = 0;
+    tail = 0;
+    uid_count = count;
+    for (int i = 0; i < count; i++) {
+        strcpy(valid_uids[tail], uids[i]);
+        tail = (tail + 1) % MAX_UIDS;
+    }
+}
+
 // Function to check if a UID is valid
 int is_valid_uid(const char* uid) {
     int index = head;
@@ -31,4 +45,114 @@ int is_valid_uid(const char* uid) {
         index = (index + 1) % MAX_UIDS;
     }
     return 0; // UID not found
+}
+
+// Function to save UIDs to NVS
+
+// Calculation for how many UIDs can be stored in NVS
+//     Overhead per entry: ~32 bytes
+//     Size of each UID: 10 bytes
+//     Total size per UID entry: 32 bytes (overhead) + 10 bytes (UID) = 42 bytes
+
+// Calculation:
+
+//     Available space: 16KB = 16384 bytes
+//     Space per UID: 42 bytes
+
+// Total available space​=16384/42=390 UIDs
+
+void save_uids_to_nvs() {
+    esp_err_t err;
+
+    nvs_handle_t nvs_handle;
+
+    int32_t uid_count_temp = (int32_t)uid_count;
+
+    // Open NVS handle
+    err = nvs_open(STORAGE_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(NVS_TAG, "Error opening NVS handle: %s\n", esp_err_to_name(err));
+        return;
+    }
+
+    // Save the UID count
+    err = nvs_set_i32(nvs_handle, "uid_count", uid_count_temp);
+    if (err != ESP_OK) {
+        ESP_LOGE(NVS_TAG, "Error saving UID count to NVS: %s\n", esp_err_to_name(err));
+        return;
+    }
+
+    // Save each UID
+    for (int i = 0; i < uid_count; i++) {
+        char key[16];
+        snprintf(key, sizeof(key), "uid_%d", i);
+        err = nvs_set_str(nvs_handle, key, valid_uids[i]);
+        
+        if (err != ESP_OK) {
+            ESP_LOGE(NVS_TAG, "Error saving UID to NVS: %s\n", esp_err_to_name(err));
+            return;
+        }
+    }
+
+    // Commit the write operation
+    err = nvs_commit(nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(NVS_TAG, "Error committing UIDs to NVS: %s\n", esp_err_to_name(err));
+    }
+
+    nvs_close(nvs_handle);
+
+    ESP_LOGI(NVS_TAG, "UIDs saved to NVS successfully.");
+}
+
+// Function to load UIDs from NVS 
+void load_uids_from_nvs() {
+    esp_err_t err;
+
+    nvs_handle_t nvs_handle;
+
+    // Open NVS handle
+    err = nvs_open(STORAGE_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(NVS_TAG, "Error opening NVS handle: %s\n", esp_err_to_name(err));
+        return;
+    }
+    
+    int32_t uid_count_temp;
+
+    // Load the UID count
+    err = nvs_get_i32(nvs_handle, "uid_count", &uid_count_temp);
+    if (err != ESP_OK) {
+        ESP_LOGE(NVS_TAG, "Error loading UID count from NVS: %s\n", esp_err_to_name(err));
+        return;
+    }
+
+    // Load each UID
+    for (int i = 0; i < uid_count_temp; i++) {
+        char key[16];
+        snprintf(key, sizeof(key), "uid_%d", i);
+        size_t required_size;
+        err = nvs_get_str(nvs_handle, key, NULL, &required_size);
+        if (err != ESP_OK) {
+            ESP_LOGE(NVS_TAG, "Error getting size of UID from NVS: %s\n", esp_err_to_name(err));
+            return;
+        }
+        err = nvs_get_str(nvs_handle, key, valid_uids[i], &required_size);
+        if (err != ESP_OK) {
+            ESP_LOGE(NVS_TAG, "Error loading UID from NVS: %s\n", esp_err_to_name(err));
+            return;
+        }
+    }
+
+    nvs_close(nvs_handle);
+
+    uid_count = (int)uid_count_temp;
+
+    ESP_LOGI(NVS_TAG, "UIDs loaded from NVS successfully.");
+
+    // Print the loaded UIDs
+    ESP_LOGI(NVS_TAG, "Loaded UIDs:");
+    for (int i = 0; i < uid_count_temp; i++) {
+        ESP_LOGI(NVS_TAG, "UID %d: %s", i, valid_uids[i]);
+    }
 }

--- a/ESP32-project/main/security.h
+++ b/ESP32-project/main/security.h
@@ -1,5 +1,8 @@
 #define MAX_UIDS 100  // Maximum number of UIDs we can store
 #define UID_LENGTH 10 // Assuming UID length to be 10 characters
 
-void add_uid(const char* uid);
 int is_valid_uid(const char* uid);
+void add_uid(const char* uid);
+void update_access_list(const char* uids[], int count);
+void save_uids_to_nvs();
+void load_uids_from_nvs();

--- a/ESP32-project/main/util.c
+++ b/ESP32-project/main/util.c
@@ -3,6 +3,7 @@
 #include "esp_log.h"
 #include "esp_heap_caps.h"
 #include "util.h"
+#include "config.h"
 
 void print_memory_info(const char *taskName) {
     UBaseType_t uxHighWaterMark = uxTaskGetStackHighWaterMark(NULL);

--- a/edge-server/edge_server.py
+++ b/edge-server/edge_server.py
@@ -1,48 +1,40 @@
+import os
+from typing import List
 import paho.mqtt.client as paho
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
+from collections import Counter
 import json
 from pydantic import BaseModel
 import api_bridge
 import time
 
+# Constants
+EDGE_MQTT_BROKER = "localhost"
+EDGE_MQTT_PORT = 1883
+CLOUD_MQTT_BROKER = "40f10495a5e44f659aa663378f527c6e.s1.eu.hivemq.cloud"
+CLOUD_MQTT_PORT = 8883
+ACCESS_LOG_FILE = "access_log.txt"
+PERIOD_UPDATE_ACCESS_LIST = 300  # 5 minutes
+PERIOD_UPDATE_LOGS = 3600 * 24 * 7  # 1 week
+PERIOD_HEARTBEAT = 1800  # 30 minutes
+VOTE_TIMEOUT = 10  # 10 seconds
+LIMIT_ACCESS_LIST_DEVICES = 100
+
+# Topics
+AUTHENTICATE_TOPIC = "/authenticate"
+ALLOW_AUTHENTICATE_TOPIC = "/allow_authentication"
+MAJORITY_VOTE_TOPIC = "/majority_vote"
+VOTE_RESPONSE_TOPIC = "/vote_response"
+ACCESS_LIST_TOPIC = "/access_list"
+REQUEST_ACCESS_LIST_TOPIC = "/request_access_list"
+RESPONSE_ACCESS_LIST_TOPIC = "/response_access_list"
+
 cloud_server_connected = False
 client_cloud = None
 
-access_list = {}
-access_logs_file = "access_log.csv"
-
-
-# MQTT Callbacks
-def on_connect_edge(client, userdata, flags, rc):
-    print("Connected with result code " + str(rc))
-    client.subscribe("#")
-
-
-def on_message_edge(client, userdata, msg):
-    global cloud_server_connected
-    global client_cloud
-    print(f"Message received {msg.payload}")
-    data = json.loads(msg.payload)
-
-    # Validate incoming data
-    try:
-        data_authenticate = AuthenticateData(
-            uid=data["uid"],
-            node_id=data["node_id"],
-            date=datetime.strptime(data["date"], "%Y-%m-%d %H:%M:%S"),
-            result=data["result"],
-        )
-
-
-    except Exception as e:
-        print(f"Invalid data: {e}")
-        return
-
-    print(
-        f"Starting authentication process for {data_authenticate.uid} at {data_authenticate.node_id} on {data_authenticate.date}"
-    )
-    process_authentication(data_authenticate)
+access_list = []
+votes_received = []
 
 
 class AuthenticateData(BaseModel):
@@ -50,6 +42,7 @@ class AuthenticateData(BaseModel):
     node_id: str
     date: datetime
     result: bool
+
 
 class AuthenticateDataOnlyStr(BaseModel):
     uid: str
@@ -64,9 +57,109 @@ class AuthenticatedData(BaseModel):
     result: bool
 
 
+# MQTT Callbacks
+def on_connect_edge(client, userdata, flags, rc):
+    print("Connected with result code " + str(rc))
+    client.subscribe(REQUEST_ACCESS_LIST_TOPIC)
+    client.subscribe(AUTHENTICATE_TOPIC)
+    client.subscribe(VOTE_RESPONSE_TOPIC)
+    client.subscribe(MAJORITY_VOTE_TOPIC)
+
+
+# MQTT on_message callback
+def on_message_edge(client, userdata, msg):
+    global cloud_server_connected, client_cloud, is_generating_keys
+
+    print(f"Message received on topic {msg.topic}: {msg.payload}")
+
+    if msg.topic == REQUEST_ACCESS_LIST_TOPIC:
+        handle_update_request(msg.payload)
+    elif msg.topic == AUTHENTICATE_TOPIC:
+        data = json.loads(msg.payload)
+        # Validate incoming data
+        try:
+            data_authenticate = AuthenticateData(
+                uid=data["uid"],
+                node_id=data["node_id"],
+                date=datetime.strptime(data["date"], "%Y-%m-%d %H:%M:%S"),
+                result=data["result"],
+            )
+
+        except Exception as e:
+            print(f"Invalid data: {e}")
+            return
+
+        print(
+            f"Starting authentication process for {data_authenticate.uid} at {data_authenticate.node_id} on {data_authenticate.date}"
+        )
+        process_authentication(data_authenticate)
+    elif msg.topic == VOTE_RESPONSE_TOPIC:
+        handle_vote_response(msg.payload)
+    elif msg.topic == MAJORITY_VOTE_TOPIC:
+        client.publish(VOTE_RESPONSE_TOPIC, json.dumps(access_list))
+
+# Function to count UID frequency in logs
+def count_uid_frequency():
+    global ACCESS_LOG_FILE
+    if not os.path.exists(ACCESS_LOG_FILE):
+        return []
+
+    with open(ACCESS_LOG_FILE, "r") as file:
+        logs = file.readlines()
+
+    past_week = datetime.now() - timedelta(days=7)
+    uid_counter = Counter()
+
+    for log in logs:
+        date_str, uid, node_id, result = log.strip().split(",")
+        log_date = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+
+        if log_date >= past_week:
+            uid_counter[uid] += 1
+
+    return uid_counter.most_common(100)
+
+def get_100_most_frequent_uids_in_access_list() -> List[str]:
+    global access_list
+    uid_frequency = count_uid_frequency()
+    most_frequent_uids = [uid for uid, _ in uid_frequency]
+
+    # Get the 100 most frequent UIDs that are in the access list
+    most_frequent_uids_in_access_list = [
+        uid for uid in most_frequent_uids if uid in access_list
+    ]
+
+    # If the frequency of the most frequent UIDs in the access list is less than 100, add UIDs from the access list that are not in the logs until
+    # it reaches 100
+    if len(most_frequent_uids_in_access_list) < LIMIT_ACCESS_LIST_DEVICES:
+        for uid in access_list:
+            if uid not in most_frequent_uids_in_access_list:
+                most_frequent_uids_in_access_list.append(uid)
+                if len(most_frequent_uids_in_access_list) == LIMIT_ACCESS_LIST_DEVICES:
+                    break
+
+    return most_frequent_uids_in_access_list
+
+
+
+def update_access_list_from_request():
+    global access_list, client
+
+    # Get the 100 most frequent UIDs in the access list
+    most_frequent_uids_in_access_list = get_100_most_frequent_uids_in_access_list()
+
+    client.publish(RESPONSE_ACCESS_LIST_TOPIC, json.dumps(most_frequent_uids_in_access_list))
+
+
+# Handle update request
+def handle_update_request(payload):
+    if payload == b"update":
+        update_access_list_from_request()
+
+
 def write_access_to_file(data: AuthenticateData):
-    global access_logs_file
-    with open(access_logs_file, "a") as file:
+    global ACCESS_LOG_FILE
+    with open(ACCESS_LOG_FILE, "a") as file:
         # Format:  %Y-%m-%d %H:%M:%S,user1,NodeA,true
         date_str = data.date.strftime("%Y-%m-%d %H:%M:%S")
         file.write(f"{date_str},{data.uid},{data.node_id},{data.result}\n")
@@ -75,7 +168,7 @@ def write_access_to_file(data: AuthenticateData):
 def process_authentication(data: AuthenticateData):
     global access_list
     global client
-    
+
     uid = data.uid
     node_id = data.node_id
     result = data.result
@@ -85,7 +178,7 @@ def process_authentication(data: AuthenticateData):
 
     # If negative result, check local access list
     if not result and uid in access_list:
-        response_topic = f"/allow_authentication"
+        response_topic = ALLOW_AUTHENTICATE_TOPIC
         authenticated_info = AuthenticatedData(uid=uid, result=True, node_id=node_id)
         new_result = True
         client.publish(response_topic, json.dumps(authenticated_info.model_dump()))
@@ -95,64 +188,111 @@ def process_authentication(data: AuthenticateData):
     # Log every authentication attempt
     new_data = AuthenticateData(uid=uid, node_id=node_id, date=date, result=new_result)
     write_access_to_file(new_data)
-    
+
     # Date is converted to format 2024-05-30 18:27:25
     date_str = new_data.date.strftime("%Y-%m-%d %H:%M:%S")
     data_authenticate_only_str = AuthenticateDataOnlyStr(
-            uid=new_data.uid,
-            node_id=new_data.node_id,
-            date=date_str,
-            result=str(new_data.result),
-        )
+        uid=new_data.uid,
+        node_id=new_data.node_id,
+        date=date_str,
+        result=str(new_data.result),
+    )
 
     if cloud_server_connected:
         # Publish to /nexxgate/access
-        client_cloud.publish("/nexxgate/access", json.dumps(data_authenticate_only_str.model_dump()))
+        client_cloud.publish(
+            "/nexxgate/access", json.dumps(data_authenticate_only_str.model_dump())
+        )
+
+
+
 
 
 # Update logs to cloud every hour
 def update_logs_to_cloud():
     global cloud_server_connected
-    global access_logs_file
+    global ACCESS_LOG_FILE
     print("Sending logs to cloud")
 
     # If file not found, create it
     try:
-        with open(access_logs_file, "r") as file:
+        with open(ACCESS_LOG_FILE, "r") as file:
             pass
     except FileNotFoundError:
-        with open(access_logs_file, "w") as file:
+        with open(ACCESS_LOG_FILE, "w") as file:
             pass
 
-
     if cloud_server_connected:
-        if api_bridge.upload_log_file(access_logs_file):
+        if api_bridge.upload_log_file(ACCESS_LOG_FILE):
             print("Logs sent to cloud")
 
             # Clear the logs file
-            with open(access_logs_file, "w") as file:
+            with open(ACCESS_LOG_FILE, "w") as file:
                 pass
         else:
             print("Failed to send logs to cloud")
-    threading.Timer(3600, update_logs_to_cloud).start()
+    threading.Timer(PERIOD_UPDATE_LOGS, update_logs_to_cloud).start()
 
 
-def update_access_list():
+# Function that updates the access list with a majority vote mechanism in case of cloud server failure
+def update_access_list_schedule():
     # Update access list from a source or modify it
-    global access_list
+    global access_list, client
     print("Updating access list")
 
     response_access_list = api_bridge.get_updated_access_list()
 
     if response_access_list is None:
-        print("Failed to update access list")
+        print("Failed to synchronize with cloud server. Starting majority vote...")
+        response_access_list = start_majority_vote()
+    else:
+        # For each access in the response, update the access list
+        access_list = []
+        for access in response_access_list:
+            access_list.append(access["uid"])
+
+        most_frequent_uids_in_access_list = get_100_most_frequent_uids_in_access_list()
+        client.publish(ACCESS_LIST_TOPIC, json.dumps(most_frequent_uids_in_access_list))
+        print("Access list updated")
+
+    threading.Timer(PERIOD_UPDATE_ACCESS_LIST, update_access_list_schedule).start()
+
+
+# Start majority vote among edge servers
+def start_majority_vote():
+    global votes_received, client, access_list
+    votes_received = []
+    client.publish(MAJORITY_VOTE_TOPIC, json.dumps(access_list))
+    threading.Timer(VOTE_TIMEOUT, conclude_majority_vote).start()
+
+
+# Handle vote response
+def handle_vote_response(payload):
+    global votes_received
+    votes_received.append(payload)
+
+
+def conclude_majority_vote():
+    global access_list, votes_received, client
+    if not votes_received:
+        print("No votes received, using local access list.")
         return
 
-    # For each access in the response, update the access list
-    for access in response_access_list:
-        access_list.update({access["uid"]: True})
+    # Count votes for each access list. Each vote is a b'["A", "B"]' string
+    votes = Counter(votes_received)
+    majority_vote = votes.most_common(1)[0][0]
+    print(f"Majority vote: {majority_vote}")
 
-    threading.Timer(300, update_access_list).start()
+    # Convert majority vote in format b'["A", "B"]' to ["A", "B"]
+    majority_vote = json.loads(majority_vote)
+
+    # Update access list
+    access_list = majority_vote
+
+    most_frequent_uids_in_access_list = get_100_most_frequent_uids_in_access_list()
+    client.publish(ACCESS_LIST_TOPIC, json.dumps(most_frequent_uids_in_access_list))
+    print("Majority vote concluded. Access list updated.")
+
 
 def heartbeat_cloud():
     global cloud_server_connected
@@ -170,13 +310,13 @@ def heartbeat_cloud():
             print("Failed to send heartbeat to cloud")
 
     # Publish to the heartbeat every half hour
-    threading.Timer(1800, heartbeat_cloud).start()
+    threading.Timer(PERIOD_HEARTBEAT, heartbeat_cloud).start()
+
 
 heartbeat_cloud()  # Start periodic updates
 # Wait 5 seconds for the server to start below
 time.sleep(5)
 
-update_access_list()  # Start periodic updates
 update_logs_to_cloud()  # Start periodic updates
 
 # Initialize MQTT Client
@@ -185,18 +325,22 @@ client = paho.Client(
 )
 client.on_connect = on_connect_edge
 client.on_message = on_message_edge
-client.connect("localhost", 1883)
+client.connect(EDGE_MQTT_BROKER, EDGE_MQTT_PORT)
 client.loop_start()
 
 # Initialize second MQTT Client for publishing to cloud
 client_cloud = paho.Client(client_id="", userdata=None, protocol=paho.MQTTv5)
 client_cloud.tls_set(tls_version=paho.ssl.PROTOCOL_TLS)
 
+
 def on_connect_cloud(client, userdata, flags, rc, properties=None):
     print("Connected to cloud with result code " + str(rc))
+
 
 client_cloud.on_connect = on_connect_cloud
 # Set password and username
 client_cloud.username_pw_set("nexxgateuser", "Nexxgate1")
-client_cloud.connect("40f10495a5e44f659aa663378f527c6e.s1.eu.hivemq.cloud", 8883)
+client_cloud.connect(CLOUD_MQTT_BROKER, CLOUD_MQTT_PORT)
 client_cloud.loop_start()
+
+update_access_list_schedule()  # Start periodic updates


### PR DESCRIPTION

- Majority Vote for Edge Computing for Updating Access Lists to avoid cloud server downtime issues
- Device contain access list of 100 most frequent accesses within the same local MQTT network, based off the cloud access list that gets syncronized every 30 minutes. This get stored in NVS memory. If the edge server is down, device on startup uses the access list previously saved on the NVS, BUT it gets validated by a majority vote between devices (cooperation) that decide on the access list to use.